### PR TITLE
Update For gramscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Complete Documentation for All-Url-Uploader Bot
 | <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v1.0.0">v1.0.0</a>             | ✘                | ☑ Upload all ytdl links, direct links                                            |
 | <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v2.0.0">v2.0.0</a>             | ✔                | ☑ Upload all ytdl links, direct links, google drive etc. (Speed is much higher than version 1) |
 | <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v2.0.1">v2.0.1</a>             | ✘                | ☑ custom thumbnail support, fixed youtube download                              |
-| <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v2.0.2">v2.0.2</a>             | ✔                | ☑ fixed Bugs in v2.0.1, Modify custom thumbnail support                          | 
+| <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v2.0.2">v2.0.2</a>             | ✔                | ☑ fixed Bugs in v2.0.1, Modify custom thumbnail support                          |
+| <a href="https://github.com/kalanakt/All-Url-Uploader/releases/tag/v2.0.3">v2.0.3</a>             | ✔                | ☑ Moved To [gramscript](https://github.com/gramscript/gramscript.py)   |                      | 
 <br>
 <h1>🎯 To do</h1>
 


### PR DESCRIPTION
**Script Updating pyrogram to [gramscript](https://github.com/gramscript/gramscript.py)**

- [ ] Main Changes
- [ ] Direct Link Download
- [ ] Youtube Link Download
- [ ] Google Drive Link Download
- [ ] Mega Drive Link Download
- [ ] PDisk Link Download
- [ ] Folder Download
- [ ] Setting Up to 2GB file support for telegram premium users


> [gramscript/gramscript.py](https://github.com/gramscript/gramscript.py) : Powerful, MTProto API framework in Python for users and bots